### PR TITLE
Dockerfile: install kernel image for current architecture

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
       git \
       img2simg \
       libguestfs-tools \
-      linux-image-amd64 \
+      linux-image-$(dpkg --print-architecture) \
       mkbootimg \
       xz-utils \
       --no-install-recommends


### PR DESCRIPTION
This makes it possible to build docker multiarch images.