### PR TITLE
Docker fastboot

### DIFF
--- a/libhelper
+++ b/libhelper
@@ -87,7 +87,7 @@ get_and_create_new_rootfs() {
 	if [ -z "${local_rootfs_file##*.gz}" ]; then
 		gunzip -k "${local_rootfs_file}"
 	fi
-	echo resize2s "${local_new_file_name}" "${local_new_size}"M
+	echo resize2fs "${local_new_file_name}" "${local_new_size}"M
 	resize2fs "${local_new_file_name}" "${local_new_size}"M
 }
 

--- a/libhelper
+++ b/libhelper
@@ -89,6 +89,13 @@ get_and_create_new_rootfs() {
 	fi
 	echo resize2fs "${local_new_file_name}" "${local_new_size}"M
 	resize2fs "${local_new_file_name}" "${local_new_size}"M
+	retcode=$?
+	if [[ ${retcode} -ne 0 ]]; then
+		echo e2fsck -f "${local_new_file_name}"
+		e2fsck -f "${local_new_file_name}"
+		echo resize2fs "${local_new_file_name}" "${local_new_size}"M
+		resize2fs "${local_new_file_name}" "${local_new_size}"M
+	fi
 }
 
 loopback_mount() {

--- a/repack_boot.sh
+++ b/repack_boot.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 
-set -e
-#set -xe
-
 . $(dirname $0)/libhelper
 
 clear_modules=0

--- a/resize_rootfs.sh
+++ b/resize_rootfs.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 # SPDX-License-Identifier: MIT
 
-set -e
-#set -xe
-
 EXTRA_SIZE=${EXTRA_SIZE:-64000}
 sparse_needed=0
 clear_modules=0


### PR DESCRIPTION
This is needed if LAVA tinkers with the rootfs and overlay's kselftests into it.
resize2fs says this:
Please run 'e2fsck -f rpb-console-image-lkft-dragonboard-410c-20210127205410.rootfs.ext4' first.