### PR TITLE
lava: board_setup: Use any image available if none specified

### DIFF
--- a/lava/board_setup.sh
+++ b/lava/board_setup.sh
@@ -5,7 +5,7 @@ set -e
 #set -xe
 
 DEVICE_TYPE=${1}
-ROOTFS_STRING=${2:-"console-image-"}
+ROOTFS_STRING=${2:-"image-"}
 kir=$(dirname $0)/..
 
 echo "PRINTOUT"


### PR DESCRIPTION
Building upon the previous change here, if no `ROOTFS_STRING` is given, look for any `image-*` file as the main image, without the `console` part of the name.