### PR TITLE
repack_boot: e850-96: fix kernel image

### DIFF
--- a/repack_boot.sh
+++ b/repack_boot.sh
@@ -74,6 +74,10 @@ fi
 
 case ${TARGET} in
 	e850-96)
+		if [[ ${kernel_file_type} = *"gzip compressed data"* ]]; then
+			gunzip ${KERNEL_FILE}
+			KERNEL_FILE=$(echo "${KERNEL_FILE}" | cut -d'.' -f1)
+		fi
 		cmdline="rw androidboot.hardware=exynos850 androidboot.selinux=permissive buildvariant=eng"
 		mkbootimg --kernel "${KERNEL_FILE}" --cmdline "${cmdline}" --os_version 10 --os_patch_level 2019-12-01 --tags_offset 0 --header_version 2 --dtb "${DTB_FILE}" --dtb_offset 0 --output boot.img
 		file boot.img


### PR DESCRIPTION
e850-96 needs an Image file to be passed in to mkbootimg.