### PR TITLE
create-ext4.rootfs: fix trailing whitespaces

### DIFF
--- a/create-ext4.rootfs.py
+++ b/create-ext4.rootfs.py
@@ -42,46 +42,46 @@ def main(args):
     with tempfile.TemporaryDirectory() as rootfs_dir:
         with tarfile.open(rootfs_tar, 'r:xz') as tf:
             def is_within_directory(directory, target):
-                
+
                 abs_directory = os.path.abspath(directory)
                 abs_target = os.path.abspath(target)
-            
+
                 prefix = os.path.commonprefix([abs_directory, abs_target])
-                
+
                 return prefix == abs_directory
-            
+
             def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-            
+
                 for member in tar.getmembers():
                     member_path = os.path.join(path, member.name)
                     if not is_within_directory(path, member_path):
                         raise Exception("Attempted Path Traversal in Tar File")
-            
-                tar.extractall(path, members, numeric_owner=numeric_owner) 
-                
-            
+
+                tar.extractall(path, members, numeric_owner=numeric_owner)
+
+
             safe_extract(tf, rootfs_dir)
             if modules_tar is not None:
                 with tarfile.open(modules_tar, 'r:xz') as tf:
                     def is_within_directory(directory, target):
-                        
+
                         abs_directory = os.path.abspath(directory)
                         abs_target = os.path.abspath(target)
-                    
+
                         prefix = os.path.commonprefix([abs_directory, abs_target])
-                        
+
                         return prefix == abs_directory
-                    
+
                     def safe_extract(tar, path=".", members=None, *, numeric_owner=False):
-                    
+
                         for member in tar.getmembers():
                             member_path = os.path.join(path, member.name)
                             if not is_within_directory(path, member_path):
                                 raise Exception("Attempted Path Traversal in Tar File")
-                    
-                        tar.extractall(path, members, numeric_owner=numeric_owner) 
-                        
-                    
+
+                        tar.extractall(path, members, numeric_owner=numeric_owner)
+
+
                     safe_extract(tf, rootfs_dir)
 
         part.set_initial_data_root(rootfs_dir)


### PR DESCRIPTION
Fixes: bb1e71621b5a ("Adding tarfile member sanitization to extractall()")