### PR TITLE
Enable module path

### DIFF
--- a/lava/board_setup.sh
+++ b/lava/board_setup.sh
@@ -6,6 +6,7 @@ set -e
 
 DEVICE_TYPE=${1}
 ROOTFS_STRING=${2:-"image-"}
+MODULES_PATH=${3:-"/"}
 kir=$(dirname $0)/..
 
 echo "PRINTOUT"
@@ -45,7 +46,7 @@ case ${DEVICE_TYPE} in
 				${kir}/repack_boot.sh -t "${machine}" -d "${local_dtb}" -k "${local_kernel}"
 				;;
 		esac
-		${kir}/resize_rootfs.sh -s -f "${local_rootfs}" -o "${local_modules}"
+		${kir}/resize_rootfs.sh -s -f "${local_rootfs}" -o "${local_modules}" -p "${MODULES_PATH}"
 		;;
 	nfs-dragonboard-845c)
 

--- a/resize_rootfs.sh
+++ b/resize_rootfs.sh
@@ -21,13 +21,16 @@ usage() {
 	echo -e "   -h, prints out this help"
 }
 
-while getopts "cd:f:hm:o:sz" arg; do
+while getopts "cd:f:hm:o:p:sz" arg; do
 	case $arg in
 	c)
 		clear_modules=1
 		;;
 	f)
 		ROOTFS_URL="$OPTARG"
+		;;
+	p)
+		MODULES_PATH="$OPTARG"
 		;;
 	o)
 		OVERLAY_URL="$OPTARG"
@@ -74,7 +77,8 @@ fi
 if [[ $clear_modules -eq 1 ]]; then
 	rm -rf "${mount_point_dir}"/lib/modules/*
 fi
-unpack_tar_file "${OVERLAY_FILE}" "${mount_point_dir}"
+mkdir -p "${mount_point_dir}${MODULES_PATH}"
+unpack_tar_file "${OVERLAY_FILE}" "${mount_point_dir}${MODULES_PATH}"
 
 if [[ "${ROOTFS_FILE}" =~ ^.*.tar* ]]; then
 	cd "${mount_point_dir}"


### PR DESCRIPTION
When using rootfs where '/lib' is a symlink from '/usr/lib', set MODULES_PATH to '/usr/' and thats where the modules will be unpacked.